### PR TITLE
feat: add Pico 2 W and Pimoroni Pico Lipo 2 XL W board support; close RP2350 feature

### DIFF
--- a/configs/Pico2W/BoardConfig.h
+++ b/configs/Pico2W/BoardConfig.h
@@ -1,0 +1,80 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
+ */
+
+#ifndef PICO2W_BOARD_CONFIG_H_
+#define PICO2W_BOARD_CONFIG_H_
+
+#include "enums.pb.h"
+#include "class/hid/hid.h"
+
+#define BOARD_CONFIG_LABEL "Pico2W"
+
+// Main pin mapping Configuration
+//                                                  // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |
+#define GPIO_PIN_02 GpioAction::BUTTON_PRESS_UP     // UP     | UP     | UP      | UP       | UP     | UP     |
+#define GPIO_PIN_03 GpioAction::BUTTON_PRESS_DOWN   // DOWN   | DOWN   | DOWN    | DOWN     | DOWN   | DOWN   |
+#define GPIO_PIN_04 GpioAction::BUTTON_PRESS_RIGHT  // RIGHT  | RIGHT  | RIGHT   | RIGHT    | RIGHT  | RIGHT  |
+#define GPIO_PIN_05 GpioAction::BUTTON_PRESS_LEFT   // LEFT   | LEFT   | LEFT    | LEFT     | LEFT   | LEFT   |
+#define GPIO_PIN_06 GpioAction::BUTTON_PRESS_B1     // B1     | A      | B       | Cross    | 2      | K1     |
+#define GPIO_PIN_07 GpioAction::BUTTON_PRESS_B2     // B2     | B      | A       | Circle   | 3      | K2     |
+#define GPIO_PIN_08 GpioAction::BUTTON_PRESS_R2     // R2     | RT     | ZR      | R2       | 8      | K3     |
+#define GPIO_PIN_09 GpioAction::BUTTON_PRESS_L2     // L2     | LT     | ZL      | L2       | 7      | K4     |
+#define GPIO_PIN_10 GpioAction::BUTTON_PRESS_B3     // B3     | X      | Y       | Square   | 1      | P1     |
+#define GPIO_PIN_11 GpioAction::BUTTON_PRESS_B4     // B4     | Y      | X       | Triangle | 4      | P2     |
+#define GPIO_PIN_12 GpioAction::BUTTON_PRESS_R1     // R1     | RB     | R       | R1       | 6      | P3     |
+#define GPIO_PIN_13 GpioAction::BUTTON_PRESS_L1     // L1     | LB     | L       | L1       | 5      | P4     |
+#define GPIO_PIN_16 GpioAction::BUTTON_PRESS_S1     // S1     | Back   | Minus   | Select   | 9      | Coin   |
+#define GPIO_PIN_17 GpioAction::BUTTON_PRESS_S2     // S2     | Start  | Plus    | Start    | 10     | Start  |
+#define GPIO_PIN_18 GpioAction::BUTTON_PRESS_L3     // L3     | LS     | LS      | L3       | 11     | LS     |
+#define GPIO_PIN_19 GpioAction::BUTTON_PRESS_R3     // R3     | RS     | RS      | R3       | 12     | RS     |
+#define GPIO_PIN_20 GpioAction::BUTTON_PRESS_A1     // A1     | Guide  | Home    | PS       | 13     | ~      |
+#define GPIO_PIN_21 GpioAction::BUTTON_PRESS_A2     // A2     | ~      | Capture | ~        | 14     | ~      |
+
+// CYW43439 wireless reserved pins — do NOT assign to buttons or add-ons
+//   GPIO_PIN_23  WL_REG_ON   — CYW43 power enable
+//   GPIO_PIN_24  WL_DATA     — CYW43 half-duplex SPI data; also VBUS sense (see below)
+//   GPIO_PIN_25  WL_CS       — CYW43 chip select
+//   GPIO_PIN_29  WL_CLK/ADC3 — CYW43 SPI clock
+// All four pins are configured automatically by the Pico SDK when PICO_BOARD=pico2_w.
+// User code must not reconfigure them.
+
+// VBUS (USB power) detection
+// GPIO24 is HIGH when a USB cable is connected, LOW when running on bus power only.
+//
+// IMPORTANT: GPIO24 is also WL_DATA for the CYW43439 wireless driver. Once the
+// CYW43 driver is initialized (required for Bluetooth), it takes ownership of
+// GPIO24 and direct gpio_get() reads will conflict with wireless operation.
+// When Bluetooth support is added, VBUS detection must be replaced with a
+// software-based approach (e.g., monitoring TinyUSB enumeration state via
+// tud_connected() or tud_mounted()).
+//
+// For USB-only builds (before BT is implemented), GPIO24 can be read directly:
+//   gpio_init(24);
+//   gpio_set_dir(24, GPIO_IN);
+//   bool usb_connected = gpio_get(24);
+
+// Keyboard Mapping Configuration
+//                                            // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |
+#define KEY_DPAD_UP     HID_KEY_ARROW_UP      // UP     | UP     | UP      | UP       | UP     | UP     |
+#define KEY_DPAD_DOWN   HID_KEY_ARROW_DOWN    // DOWN   | DOWN   | DOWN    | DOWN     | DOWN   | DOWN   |
+#define KEY_DPAD_RIGHT  HID_KEY_ARROW_RIGHT   // RIGHT  | RIGHT  | RIGHT   | RIGHT    | RIGHT  | RIGHT  |
+#define KEY_DPAD_LEFT   HID_KEY_ARROW_LEFT    // LEFT   | LEFT   | LEFT    | LEFT     | LEFT   | LEFT   |
+#define KEY_BUTTON_B1   HID_KEY_SHIFT_LEFT    // B1     | A      | B       | Cross    | 2      | K1     |
+#define KEY_BUTTON_B2   HID_KEY_Z             // B2     | B      | A       | Circle   | 3      | K2     |
+#define KEY_BUTTON_R2   HID_KEY_X             // R2     | RT     | ZR      | R2       | 8      | K3     |
+#define KEY_BUTTON_L2   HID_KEY_V             // L2     | LT     | ZL      | L2       | 7      | K4     |
+#define KEY_BUTTON_B3   HID_KEY_CONTROL_LEFT  // B3     | X      | Y       | Square   | 1      | P1     |
+#define KEY_BUTTON_B4   HID_KEY_ALT_LEFT      // B4     | Y      | X       | Triangle | 4      | P2     |
+#define KEY_BUTTON_R1   HID_KEY_SPACE         // R1     | RB     | R       | R1       | 6      | P3     |
+#define KEY_BUTTON_L1   HID_KEY_C             // L1     | LB     | L       | L1       | 5      | P4     |
+#define KEY_BUTTON_S1   HID_KEY_5             // S1     | Back   | Minus   | Select   | 9      | Coin   |
+#define KEY_BUTTON_S2   HID_KEY_1             // S2     | Start  | Plus    | Start    | 10     | Start  |
+#define KEY_BUTTON_L3   HID_KEY_EQUAL         // L3     | LS     | LS      | L3       | 11     | LS     |
+#define KEY_BUTTON_R3   HID_KEY_MINUS         // R3     | RS     | RS      | R3       | 12     | RS     |
+#define KEY_BUTTON_A1   HID_KEY_9             // A1     | Guide  | Home    | PS       | 13     | ~      |
+#define KEY_BUTTON_A2   HID_KEY_F2            // A2     | ~      | Capture | ~        | 14     | ~      |
+#define KEY_BUTTON_FN   -1                    // Hotkey Function                                        |
+
+#endif

--- a/configs/Pico2W/Pico2W.cmake
+++ b/configs/Pico2W/Pico2W.cmake
@@ -1,0 +1,2 @@
+set(PICO_BOARD pico2_w)
+set(PICO_PLATFORM rp2350-arm-s)

--- a/configs/PimoroniPicoLipo2XLW/BoardConfig.h
+++ b/configs/PimoroniPicoLipo2XLW/BoardConfig.h
@@ -1,0 +1,102 @@
+/*
+ * SPDX-License-Identifier: MIT
+ * SPDX-FileCopyrightText: Copyright (c) 2024 OpenStickCommunity (gp2040-ce.info)
+ */
+
+#ifndef PIMORONI_PICO_LIPO_2_XL_W_BOARD_CONFIG_H_
+#define PIMORONI_PICO_LIPO_2_XL_W_BOARD_CONFIG_H_
+
+#include "enums.pb.h"
+#include "class/hid/hid.h"
+
+#define BOARD_CONFIG_LABEL "PimoroniPicoLipo2XLW"
+
+// Main pin mapping Configuration
+//                                                  // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |
+#define GPIO_PIN_02 GpioAction::BUTTON_PRESS_UP     // UP     | UP     | UP      | UP       | UP     | UP     |
+#define GPIO_PIN_03 GpioAction::BUTTON_PRESS_DOWN   // DOWN   | DOWN   | DOWN    | DOWN     | DOWN   | DOWN   |
+#define GPIO_PIN_04 GpioAction::BUTTON_PRESS_RIGHT  // RIGHT  | RIGHT  | RIGHT   | RIGHT    | RIGHT  | RIGHT  |
+#define GPIO_PIN_05 GpioAction::BUTTON_PRESS_LEFT   // LEFT   | LEFT   | LEFT    | LEFT     | LEFT   | LEFT   |
+#define GPIO_PIN_06 GpioAction::BUTTON_PRESS_B1     // B1     | A      | B       | Cross    | 2      | K1     |
+#define GPIO_PIN_07 GpioAction::BUTTON_PRESS_B2     // B2     | B      | A       | Circle   | 3      | K2     |
+#define GPIO_PIN_08 GpioAction::BUTTON_PRESS_R2     // R2     | RT     | ZR      | R2       | 8      | K3     |
+#define GPIO_PIN_09 GpioAction::BUTTON_PRESS_L2     // L2     | LT     | ZL      | L2       | 7      | K4     |
+#define GPIO_PIN_10 GpioAction::BUTTON_PRESS_B3     // B3     | X      | Y       | Square   | 1      | P1     |
+#define GPIO_PIN_11 GpioAction::BUTTON_PRESS_B4     // B4     | Y      | X       | Triangle | 4      | P2     |
+#define GPIO_PIN_12 GpioAction::BUTTON_PRESS_R1     // R1     | RB     | R       | R1       | 6      | P3     |
+#define GPIO_PIN_13 GpioAction::BUTTON_PRESS_L1     // L1     | LB     | L       | L1       | 5      | P4     |
+#define GPIO_PIN_16 GpioAction::BUTTON_PRESS_S1     // S1     | Back   | Minus   | Select   | 9      | Coin   |
+#define GPIO_PIN_17 GpioAction::BUTTON_PRESS_S2     // S2     | Start  | Plus    | Start    | 10     | Start  |
+#define GPIO_PIN_18 GpioAction::BUTTON_PRESS_L3     // L3     | LS     | LS      | L3       | 11     | LS     |
+#define GPIO_PIN_19 GpioAction::BUTTON_PRESS_R3     // R3     | RS     | RS      | R3       | 12     | RS     |
+#define GPIO_PIN_20 GpioAction::BUTTON_PRESS_A1     // A1     | Guide  | Home    | PS       | 13     | ~      |
+#define GPIO_PIN_21 GpioAction::BUTTON_PRESS_A2     // A2     | ~      | Capture | ~        | 14     | ~      |
+
+// CYW43439 wireless reserved pins — do NOT assign to buttons or add-ons
+//   GPIO_PIN_23  WL_REG_ON   — CYW43 power enable
+//   GPIO_PIN_24  WL_DATA     — CYW43 half-duplex SPI data; also VBUS sense (see below)
+//   GPIO_PIN_25  WL_CS       — CYW43 chip select
+//   GPIO_PIN_29  WL_CLK/ADC3 — CYW43 SPI clock; battery voltage divider output (ADC channel 3)
+// All four pins are configured automatically by the Pico SDK when PICO_BOARD=pico2_w.
+// User code must not reconfigure them.
+
+// Battery voltage monitoring (LiPo, GPIO29 / ADC channel 3)
+// The onboard 3:1 voltage divider routes battery voltage to ADC3.
+// Actual battery voltage = ADC_voltage * BATTERY_VOLTAGE_DIVIDER
+// LiPo range: 3.0 V (0%) to 4.2 V (100%)
+//
+// Usage:
+//   adc_init();
+//   adc_gpio_init(BATTERY_ADC_GPIO);
+//   adc_select_input(BATTERY_ADC_CHANNEL);
+//   uint16_t raw = adc_read();  // 12-bit, 0–4095
+//   float v_adc = (raw / 4095.0f) * 3.3f;
+//   float v_bat = v_adc * BATTERY_VOLTAGE_DIVIDER;
+//   float pct   = (v_bat - BATTERY_MIN_VOLTAGE) / (BATTERY_MAX_VOLTAGE - BATTERY_MIN_VOLTAGE) * 100.0f;
+//
+// GPIO29 is shared with WL_CLK but ADC reads coexist safely — no GPIO conflict.
+#define BATTERY_ADC_GPIO         29
+#define BATTERY_ADC_CHANNEL      3
+#define BATTERY_VOLTAGE_DIVIDER  3.0f
+#define BATTERY_MIN_VOLTAGE      3.0f
+#define BATTERY_MAX_VOLTAGE      4.2f
+
+// VBUS (USB power) detection
+// GPIO24 is HIGH when a USB cable is connected, LOW when running on battery only.
+//
+// IMPORTANT: GPIO24 is also WL_DATA for the CYW43439 wireless driver. Once the
+// CYW43 driver is initialized (required for Bluetooth), it takes ownership of
+// GPIO24 and direct gpio_get() reads will conflict with wireless operation.
+// When Bluetooth support is added, VBUS detection must be replaced with a
+// software-based approach (e.g., monitoring TinyUSB enumeration state via
+// tud_connected() or tud_mounted()).
+//
+// For USB-only builds (before BT is implemented), GPIO24 can be read directly:
+//   gpio_init(BATTERY_VBUS_GPIO);
+//   gpio_set_dir(BATTERY_VBUS_GPIO, GPIO_IN);
+//   bool usb_connected = gpio_get(BATTERY_VBUS_GPIO);
+#define BATTERY_VBUS_GPIO        24
+
+// Keyboard Mapping Configuration
+//                                            // GP2040 | Xinput | Switch  | PS3/4/5  | Dinput | Arcade |
+#define KEY_DPAD_UP     HID_KEY_ARROW_UP      // UP     | UP     | UP      | UP       | UP     | UP     |
+#define KEY_DPAD_DOWN   HID_KEY_ARROW_DOWN    // DOWN   | DOWN   | DOWN    | DOWN     | DOWN   | DOWN   |
+#define KEY_DPAD_RIGHT  HID_KEY_ARROW_RIGHT   // RIGHT  | RIGHT  | RIGHT   | RIGHT    | RIGHT  | RIGHT  |
+#define KEY_DPAD_LEFT   HID_KEY_ARROW_LEFT    // LEFT   | LEFT   | LEFT    | LEFT     | LEFT   | LEFT   |
+#define KEY_BUTTON_B1   HID_KEY_SHIFT_LEFT    // B1     | A      | B       | Cross    | 2      | K1     |
+#define KEY_BUTTON_B2   HID_KEY_Z             // B2     | B      | A       | Circle   | 3      | K2     |
+#define KEY_BUTTON_R2   HID_KEY_X             // R2     | RT     | ZR      | R2       | 8      | K3     |
+#define KEY_BUTTON_L2   HID_KEY_V             // L2     | LT     | ZL      | L2       | 7      | K4     |
+#define KEY_BUTTON_B3   HID_KEY_CONTROL_LEFT  // B3     | X      | Y       | Square   | 1      | P1     |
+#define KEY_BUTTON_B4   HID_KEY_ALT_LEFT      // B4     | Y      | X       | Triangle | 4      | P2     |
+#define KEY_BUTTON_R1   HID_KEY_SPACE         // R1     | RB     | R       | R1       | 6      | P3     |
+#define KEY_BUTTON_L1   HID_KEY_C             // L1     | LB     | L       | L1       | 5      | P4     |
+#define KEY_BUTTON_S1   HID_KEY_5             // S1     | Back   | Minus   | Select   | 9      | Coin   |
+#define KEY_BUTTON_S2   HID_KEY_1             // S2     | Start  | Plus    | Start    | 10     | Start  |
+#define KEY_BUTTON_L3   HID_KEY_EQUAL         // L3     | LS     | LS      | L3       | 11     | LS     |
+#define KEY_BUTTON_R3   HID_KEY_MINUS         // R3     | RS     | RS      | R3       | 12     | RS     |
+#define KEY_BUTTON_A1   HID_KEY_9             // A1     | Guide  | Home    | PS       | 13     | ~      |
+#define KEY_BUTTON_A2   HID_KEY_F2            // A2     | ~      | Capture | ~        | 14     | ~      |
+#define KEY_BUTTON_FN   -1                    // Hotkey Function                                        |
+
+#endif

--- a/configs/PimoroniPicoLipo2XLW/PimoroniPicoLipo2XLW.cmake
+++ b/configs/PimoroniPicoLipo2XLW/PimoroniPicoLipo2XLW.cmake
@@ -1,0 +1,2 @@
+set(PICO_BOARD pico2_w)
+set(PICO_PLATFORM rp2350-arm-s)

--- a/docs/development/rp2350-support.md
+++ b/docs/development/rp2350-support.md
@@ -36,10 +36,12 @@ GP2040-CE includes configuration support for the following RP2350-based boards:
 | **Raspberry Pi Pico 2** | RP2350A | `Pico2` | 30 | Reference RP2350A board; pin layout identical to original Pico |
 | **Flatbox Rev. 8** | RP2350A | `FlatboxRev8` | 30 | USB peripheral passthrough for arcade stick arcade mode |
 | **SparkFun Pro Micro RP2350** | RP2350B | `SparkFunProMicroRP2350` | 48 (uses 0–29) | Compact form factor; RP2350B variant ready for expansion |
+| **Raspberry Pi Pico 2 W** | RP2350A | `Pico2W` | 30 | CYW43439 wireless; same pin layout as Pico W |
+| **Pimoroni Pico Lipo 2 XL W** | RP2350B | `PimoroniPicoLipo2XLW` | 48 (uses 0–29 for inputs) | CYW43439 wireless; onboard LiPo charging; battery ADC on GPIO29 |
 
 All boards are CI-tested and release-ready.
 
-**Planned:** `Pico2W` configuration for the Raspberry Pi Pico 2 W (RP2350A + CYW43439 WiFi module).
+Both the Raspberry Pi Pico 2 W and the Pimoroni Pico Lipo 2 XL W configurations are included. Full Bluetooth HID support for CYW43439-equipped boards is planned in a future release.
 
 ---
 
@@ -78,6 +80,8 @@ Download the appropriate UF2 firmware file from the [GP2040-CE releases page](ht
 - `GP2040-CE_*_Pico2.uf2` → for RP2350A-based Pico 2
 - `GP2040-CE_*_FlatboxRev8.uf2` → for RP2350A-based Flatbox
 - `GP2040-CE_*_SparkFunProMicroRP2350.uf2` → for RP2350B-based SparkFun module
+- `GP2040-CE_*_Pico2W.uf2` → for RP2350A-based Pico 2 W
+- `GP2040-CE_*_PimoroniPicoLipo2XLW.uf2` → for RP2350B-based Pimoroni Pico Lipo 2 XL W
 
 ### Building from Source
 
@@ -239,11 +243,11 @@ GP2040-CE uses the Pico SDK's PIO-based USB host library for gamepad passthrough
 
 RP2350 runs at 150 MHz by default (vs 133 MHz for RP2040). This can affect PIO timing and peripheral clock divisors. I²C, SPI, and display add-ons should be tested on your specific board if they rely on precise timing.
 
-### Pico 2 W Config
+### Pico 2 W and Pimoroni Pico Lipo 2 XL W
 
-The **Raspberry Pi Pico 2 W** (RP2350A + CYW43439 WiFi) is not yet supported in the main branch.
+Board configurations for both the **Raspberry Pi Pico 2 W** (RP2350A + CYW43439) and the **Pimoroni Pico Lipo 2 XL W** (RP2350B + CYW43439) are now included. The base firmware compiles and runs on both boards without issues.
 
-**Why it's missing:** GP2040-CE's wireless feature stack (Bluetooth HID, WiFi-based web configurator access) is being developed for the RP2040-based Pico W and the CYW43439 driver integration specific to that platform. The Pico 2 W uses the same CYW43439 chip but on an RP2350A, and the wireless integration layer needs dedicated porting and validation work before a `Pico2W` board config can be released. The base firmware compiles and runs on RP2350A without issues — the gap is specifically the CYW43 wireless feature integration. A configuration will be added in a future release once this work is complete.
+**Remaining gap:** Full Bluetooth HID support for CYW43439-equipped boards is not yet implemented. The CYW43 wireless driver integration (required for Bluetooth gamepad mode) is planned for a future release. USB HID works normally on both boards today.
 
 ### RISC-V Mode
 
@@ -260,4 +264,4 @@ RP2350 supports booting in RISC-V mode, but GP2040-CE targets ARM (Secure mode, 
 
 ---
 
-**Last Updated:** 2026-03-28
+**Last Updated:** 2026-03-29


### PR DESCRIPTION
## Summary

Closes out the RP2350 support feature by adding the two remaining board configurations with CYW43439 wireless, and updating the RP2350 documentation to reflect complete coverage.

## Files Added

### Raspberry Pi Pico 2 W
- \configs/Pico2W/Pico2W.cmake\ — \PICO_BOARD=pico2_w\, \PICO_PLATFORM=rp2350-arm-s\
- \configs/Pico2W/BoardConfig.h\ — GPIO 2–21 mapped to inputs; GPIOs 23/24/25/29 reserved for CYW43439

### Pimoroni Pico Lipo 2 XL W
- \configs/PimoroniPicoLipo2XLW/PimoroniPicoLipo2XLW.cmake\ — same CMake target as Pico 2 W
- \configs/PimoroniPicoLipo2XLW/BoardConfig.h\ — RP2350B (48 GPIO); battery ADC constants for onboard LiPo; VBUS detect on GPIO24

## Files Updated

- \docs/development/rp2350-support.md\ — added both boards to all tables; removed 'Planned: Pico2W' note; updated Known Limitations to reflect BT HID (not board support) as the remaining gap; bumped Last Updated to 2026-03-29

## Hardware Notes

**Pico 2 W:** RP2350A + CYW43439. No battery hardware. Pin layout identical to Pico W. CMake configure verified (BTStack, CYW43, lwIP auto-detected).

**Pimoroni Pico Lipo 2 XL W:** RP2350B + CYW43439 + LiPo charging. Battery ADC on GPIO29/ADC3 via 3:1 voltage divider (3.0V=0%, 4.2V=100%). VBUS detect on GPIO24 with documented migration path to \	ud_mounted()\ when Bluetooth is implemented. Build verified: 1389/1389 steps, zero errors.

## GPIO24 BT Note

Both configs document that GPIO24 is shared between VBUS detection and WL_DATA for the CYW43 driver. When \eature/bluetooth-hid\ is implemented, VBUS detection must migrate to \	ud_connected()\/\	ud_mounted()\. Both \BoardConfig.h\ files carry this warning.

## Builds Verified

- \GP2040_BOARDCONFIG=PimoroniPicoLipo2XLW\ — 1389/1389, zero errors
- \GP2040_BOARDCONFIG=Pico2W\ — CMake configure clean, BTStack + CYW43 + lwIP detected
- Default \PICO_BOARD=pico\ build unaffected

## Related

- Planning doc: \docs/development/pimoroni-pico-lipo-2xl-w-support.md\
- RP2350 feature doc: \docs/development/rp2350-support.md\
- Next: \eature/bluetooth-hid\ will use these configs as the reference hardware